### PR TITLE
Update template.rb to work with haml 4

### DIFF
--- a/merb-haml/lib/merb-haml/template.rb
+++ b/merb-haml/lib/merb-haml/template.rb
@@ -49,7 +49,7 @@ module Haml
 
       setup = "@_engine = 'haml'"
 
-      object.send(method, "def #{name}(_haml_locals = {}); #{setup}; #{precompiled_with_ambles(local_names)}; end",
+      object.send(method, "def #{name}(_haml_locals = {}); #{setup}; #{compiler.precompiled_with_ambles(local_names)}; end",
                   @options[:filename], 0)
     end
  


### PR DESCRIPTION
In version 4 and higher of haml, the Haml engine doesn't have a method `precompiled_with_ambles`. This method is implemented in the Haml::Compiler class, and every engine has `compiler` attribute of that class. This change is needed to make the tests pass with haml 4. It reflects the definition of the `def_method` method in `Haml::Engine`.
